### PR TITLE
Update guardrails_ai.md

### DIFF
--- a/docs/my-website/docs/proxy/guardrails/guardrails_ai.md
+++ b/docs/my-website/docs/proxy/guardrails/guardrails_ai.md
@@ -2,9 +2,9 @@ import Image from '@theme/IdealImage';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Guardrails.ai
+# Guardrails AI
 
-Use [Guardrails.ai](https://www.guardrailsai.com/) to add checks to LLM output.
+Use Guardrails AI ([guardrailsai.com](https://www.guardrailsai.com/)) to add checks to LLM output.
 
 ## Pre-requisites
 


### PR DESCRIPTION
Fix the page title and link to highlight the correct website https://guardrailsai.com which is the real name/website of this provider.

The https://guardrails.ai website unexpectedly leads to some other product (placeholder landing page with "get early access" status), which is confusing.

## Title

Update guardrails_ai.md

## Type

📖 Documentation